### PR TITLE
2 additions to Frames.lua (uncombined bags & esc menu)

### DIFF
--- a/Frames.lua
+++ b/Frames.lua
@@ -121,6 +121,17 @@ BlizzMoveAPI:RegisterFrames(
             }
         }
     },
+    ["ContainerFrame1"] =
+    {
+        MinVersion = 100000,
+        SubFrames =
+        {
+            ["ContainerFrame1.TitleContainer"] =
+            {
+                MinVersion = 110000,
+            }
+        }
+    },
     ["DestinyFrame"] =
     {
         MinVersion = 50000,
@@ -217,6 +228,13 @@ BlizzMoveAPI:RegisterFrames(
     ["GameMenuFrame"] =
     {
         MinVersion = 0,
+        SubFrames =
+    {
+        ["GameMenuFrame.Header"] =
+        {
+            MinVersion = 110000,
+        }
+    }
     },
     ["GossipFrame"] =
     {


### PR DESCRIPTION
1) Added the Frame ContainerFrame1 and its SubFrame ContainerFrame1.TitleContainer - this allows for moving of the backpack bag window (when they're not combined), and moving the backpack also moves all the other opened bags (including reagent bag) with it.

2) Added a SubFrame to GameMenuFrame (GameMenuFrame.Header), which allows for movement and rescaling of the new (11.0) extra large escape menu.