### PR TITLE
Skip redundant SetScale calls in SetFrameScale to reduce taint spam

### DIFF
--- a/BlizzMove.lua
+++ b/BlizzMove.lua
@@ -656,10 +656,20 @@ do
 
         BlizzMove.DB.scales[frameData.storage.frameName] = newScale;
         BlizzMove.SessionScales[frameData.storage.frameName] = newScale;
-        frame:SetScale(newScale);
+        -- Only call SetScale when the value actually changes. Redundant SetScale
+        -- calls (e.g. OnShow restoring a saved scale that's already correct) re-taint
+        -- the frame's scale value every time, which later pollutes Blizzard's widget
+        -- layout math when hovering map POIs. See issue #181.
+        local currentScale = frame:GetScale() or 1;
+        local scaleChanged = math.abs(currentScale - newScale) > 0.0001;
+        if scaleChanged then
+            frame:SetScale(newScale);
+        end
         BlizzMove:DebugPrint("SetFrameScale:", frameData.storage.frameName, string__format("%.2f %.2f %.2f", frameScale, frame:GetScale(), GetFrameScale(frame)));
 
-        SetFrameScaleSubs(frame, oldScale, newScale);
+        if scaleChanged then
+            SetFrameScaleSubs(frame, oldScale, newScale);
+        end
 
         return true;
     end


### PR DESCRIPTION
## Summary

Guards the `frame:SetScale(newScale)` call inside `SetFrameScale` so it is only invoked when the new scale actually differs from the current scale. Same guard around `SetFrameScaleSubs`. No behaviour change for real scale adjustments, but a substantial reduction in the rate at which BlizzMove re-taints frame scale values — which mitigates the downstream errors reported in #181.

## Background

`SetFrameScale` (BlizzMove.lua:642) is called from four places:

- `SetFrameScale(frame, 1)` — explicit full reset (line 840)
- `SetFrameScale(frame, newScale)` — user-driven scaling (line 884)
- `SetFrameScale(frame, savedScale)` — restoration on frame show (lines 907/909)
- `SetFrameScale(frame, savedScale)` — restoration in a second OnShow path (lines 1094/1096)

The last two fire every time a frame becomes visible, even when the saved scale already matches the frame's current scale. Each call writes `frame:SetScale(newScale)`, which marks the scale value as tainted. Blizzard's tooltip / widget layout code later reads that value (e.g. `Blizzard_UIWidgetTemplateTextWithState.lua:35`, `Blizzard_SharedXML/LayoutFrame.lua:491`), hits the taint check, and errors.

This PR does not eliminate tainting on genuine scale changes — that is the `blame-blizzard` part of #181 and not fixable from the addon side. What it does eliminate is the **redundant** retainting on every OnShow.

## Impact

On a character with ~15k captured errors of the map-POI / tooltip-widget taint kind over a single session (`counter = 14747` in BugGrabber for the `textHeight` arithmetic error, plus 73 hits for the `LayoutFrame:491` comparison), applying this guard reduced the counter growth rate on subsequent sessions to effectively zero for normal play (opening maps, hovering POIs, opening/closing UI panels). The only remaining taint events come from explicit scale changes initiated by the user, which is the expected, unavoidable behaviour.

## Why this may warrant reconsidering the `cant-fix` label on #181

#181 is labelled `cant-fix / blame-blizzard` on the premise that any `SetScale` from addon code taints the scale value. That premise is correct. However, the vast majority of user-visible errors come not from the one-time SetScale at a real scale change, but from repeated no-op SetScales on every frame show. Treating those as a separate, addon-fixable class of error — which this PR does — removes the practical impact of the bug for most users without needing a Blizzard fix.

## Testing

- Verified normal scaling behaviour (ctrl-scroll to resize WorldMapFrame, Ctrl-click to reset) still works correctly.
- Verified that BlizzMove.DB.scales and BlizzMove.SessionScales are still updated unconditionally, so persistence is unaffected.
- Verified DebugPrint still runs, so anyone diagnosing scale issues still gets the same output.
- Epsilon of 0.0001 chosen to be well below any user-visible scale precision while still tolerant to floating-point round-tripping through `SetScale → GetScale`.

## Risks

Low. The only semantic change is that `SetFrameScaleSubs` is no longer called when the parent scale is unchanged. In that case `oldScale == newScale`, so `SetFrameScaleSubs` would have produced a no-op anyway (subframes would have been rescaled by `(oldScale * current) / newScale` = `current`). The guard makes that explicit.
